### PR TITLE
Solving problem with friendship disappear

### DIFF
--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -413,7 +413,7 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                         else:
                             try:
                                 print('comming as uuid')
-                                friend_uuid = UUID(friend_uuid)
+                                friend_uuid = UUID(friend_url)
                             except:
                                 print("Author/Friend id in bad format")
                     except:

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -395,16 +395,12 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
             response_friendlist = response.json()["authors"]
             response_friendlist_set=set([re.sub('.+/author/', '', friend) for friend in response_friendlist])
             local_friend_set = set([re.sub('.+/author/','',friend)for friend in local_friend_list_of_remote_user])
-            print("local_friend_set is {}".format(local_friend_set))
-            print("response_friendlist_set is {}".format(response_friendlist_set))
             extra_friend = local_friend_set - response_friendlist_set
-            print('extra_friend is {}'.format(extra_friend))
             my_host = request.get_host()
             try:
                 for friend_url in extra_friend:
                     try:
                         if 'author/' in friend_url:
-                            print('comming as url')
                             friend_uuid = friend_url.split('author/')[1]
                             try:
                                 friend_uuid = UUID(friend_uuid)
@@ -412,7 +408,6 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                                 print("Author/Friend id in bad format")
                         else:
                             try:
-                                print('comming as uuid')
                                 friend_uuid = UUID(friend_url)
                             except:
                                 print("Author/Friend id in bad format")

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -399,6 +399,7 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
             # response_friendlist_set = set(response.json()["authors"])
             local_friend_set = set([re.sub('.+/author/','',friend)for friend in local_friend_list_of_remote_user])
             extra_friend = local_friend_set - response_friendlist_set
+            print('extra_friend is {}'.format(extra_friend))
             my_host = request.get_host()
             try:
                 for friend_url in extra_friend:
@@ -413,6 +414,7 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                         else:
                             try:
                                 print('comming as uuid')
+                                print(friend_url)
                                 friend_uuid = UUID(friend_url)
                             except:
                                 print("Author/Friend id in bad format")

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -374,9 +374,11 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
     local_friend_list_of_remote_user = []
     # local_friends_obj_list = list(Friend.objects.filter(Q(author=remote_authorObj)|Q(friend=remote_authorObj)))
     if Friend.objects.filter(author=remote_authorObj).exists():
-        local_friend_list_of_remote_user += [friend.friend.host+"service/author/"+str(friend.friend.id) for friend in list(Friend.objects.filter(author=remote_authorObj))]
+        local_friend_list_of_remote_user += [friend.friend.host+"service/author/"+str(friend.friend.id) 
+        for friend in list(Friend.objects.filter(author=remote_authorObj))]
     if Friend.objects.filter(friend=remote_authorObj).exists():
-        local_friend_list_of_remote_user += [friend.author.host+"service/author/"+str(friend.author.id) for friend in list(Friend.objects.filter(friend=remote_authorObj))]
+        local_friend_list_of_remote_user += [friend.author.host+"service/author/"+str(friend.author.id) 
+        for friend in list(Friend.objects.filter(friend=remote_authorObj))]
 
 
     if local_friend_list_of_remote_user:
@@ -392,14 +394,17 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
         data = json.dumps(request_body)
         response = requests.post(request_url,headers=headers,data=data,auth=HTTPBasicAuth(remote_to_node.remoteUsername,remote_to_node.remotePassword))
         if response.status_code == 200:
-            response_friendlist_set = set(response.json()["authors"])
-            local_friend_set = set(local_friend_list_of_remote_user)
+            response_friendlist = response.json()["authors"]
+            response_friendlist_set=set([re.sub('.+/author/', '', friend) for friend in response_friendlist])
+            # response_friendlist_set = set(response.json()["authors"])
+            local_friend_set = set([re.sub('.+/author/','',friend)for friend in local_friend_list_of_remote_user])
             extra_friend = local_friend_set - response_friendlist_set
             my_host = request.get_host()
             try:
                 for friend_url in extra_friend:
                     try:
                         if 'author/' in friend_url:
+                            print('comming as url')
                             friend_uuid = friend_url.split('author/')[1]
                             try:
                                 friend_uuid = UUID(friend_uuid)
@@ -407,6 +412,7 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                                 print("Author/Friend id in bad format")
                         else:
                             try:
+                                print('comming as uuid')
                                 friend_uuid = UUID(friend_uuid)
                             except:
                                 print("Author/Friend id in bad format")

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -398,6 +398,8 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
             response_friendlist_set=set([re.sub('.+/author/', '', friend) for friend in response_friendlist])
             # response_friendlist_set = set(response.json()["authors"])
             local_friend_set = set([re.sub('.+/author/','',friend)for friend in local_friend_list_of_remote_user])
+            print("local_friend_set is {}".format(local_friend_set))
+            print("response_friendlist_set is {}".format(response_friendlist_set))
             extra_friend = local_friend_set - response_friendlist_set
             print('extra_friend is {}'.format(extra_friend))
             my_host = request.get_host()

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -424,8 +424,11 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                         print("Author/Friend id in bad format")
                     friend_obj = Author.objects.get(Q(pk=friend_uuid))
                     if Friend.objects.filter(Q(author=friend_obj), Q(friend=remote_authorObj), Q(status="Accept")).exists():
+                        print('deleing 1')
                         Friend.objects.get(Q(author=friend_obj), Q(friend=remote_authorObj), Q(status="Accept")).delete()
                     if Friend.objects.filter(Q(friend=friend_obj), Q(author=remote_authorObj),Q(status="Accept")).exists():
+                        print('deleing 2')
+
                         Friend.objects.get(Q(friend=friend_obj), Q(author=remote_authorObj),Q(status="Accept")).delete()
 
             except Exception as e:

--- a/myBlog/Helpers.py
+++ b/myBlog/Helpers.py
@@ -372,7 +372,6 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
     remote_host = remoteNode.host
     remote_to_node = RemoteUser.objects.get(node=remoteNode)
     local_friend_list_of_remote_user = []
-    # local_friends_obj_list = list(Friend.objects.filter(Q(author=remote_authorObj)|Q(friend=remote_authorObj)))
     if Friend.objects.filter(author=remote_authorObj).exists():
         local_friend_list_of_remote_user += [friend.friend.host+"service/author/"+str(friend.friend.id) 
         for friend in list(Friend.objects.filter(author=remote_authorObj))]
@@ -382,7 +381,6 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
 
 
     if local_friend_list_of_remote_user:
-        # local_friend_list_of_remote_user = [str(friend.id) for friend in local_friends_obj_list]
         request_body = {
             "query":"friends",
             "author":remote_host + "service/author/"+str(remote_user_uuid),
@@ -396,7 +394,6 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
         if response.status_code == 200:
             response_friendlist = response.json()["authors"]
             response_friendlist_set=set([re.sub('.+/author/', '', friend) for friend in response_friendlist])
-            # response_friendlist_set = set(response.json()["authors"])
             local_friend_set = set([re.sub('.+/author/','',friend)for friend in local_friend_list_of_remote_user])
             print("local_friend_set is {}".format(local_friend_set))
             print("response_friendlist_set is {}".format(response_friendlist_set))
@@ -416,7 +413,6 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                         else:
                             try:
                                 print('comming as uuid')
-                                print(friend_url)
                                 friend_uuid = UUID(friend_url)
                             except:
                                 print("Author/Friend id in bad format")
@@ -424,11 +420,8 @@ def update_this_friendship(remoteNode,remote_user_uuid,request):
                         print("Author/Friend id in bad format")
                     friend_obj = Author.objects.get(Q(pk=friend_uuid))
                     if Friend.objects.filter(Q(author=friend_obj), Q(friend=remote_authorObj), Q(status="Accept")).exists():
-                        print('deleing 1')
                         Friend.objects.get(Q(author=friend_obj), Q(friend=remote_authorObj), Q(status="Accept")).delete()
                     if Friend.objects.filter(Q(friend=friend_obj), Q(author=remote_authorObj),Q(status="Accept")).exists():
-                        print('deleing 2')
-
                         Friend.objects.get(Q(friend=friend_obj), Q(author=remote_authorObj),Q(status="Accept")).delete()
 
             except Exception as e:

--- a/myBlog/static/js/author_details_helpers.js
+++ b/myBlog/static/js/author_details_helpers.js
@@ -95,7 +95,7 @@ function sendFollowRequest(author_id,author_host,author_name,author_url,currentU
             'id':currentUserID,
             'host':host,
             'displayName':currentUserName,
-            'url': host + currentUserID,
+            'url': host +'author/'+ currentUserID,
         },
         "friend":{
             'id':author_id,


### PR DESCRIPTION
Andrew's team use 'author.url' in sendFollowRequest to create new Author object. Added 'author/' when sending FR in front-end.
In 'update-this-friendship' function, I used Regular Expression to get rid of stuff other than uuid in url.
Please test if it works for team WAVE.